### PR TITLE
Remove overrides

### DIFF
--- a/clusters/inteli-stage/oem/api/values.yaml
+++ b/clusters/inteli-stage/oem/api/values.yaml
@@ -4,11 +4,10 @@ ingress:
   className: nginx-oem
 dscpIpfs:
   enabled: true
-  nameOverride: vitalamipfs
   config:
     logLevel: info
     ipfsLogLevel: fatal
-    ipfsBootNodeAddress: /dns4/oem-ipfs-bn-vitalam-ipfs-swarm.oem.svc.cluster.local/tcp/4001/p2p/12D3KooWJ1ZBoSYADNep8S23MPRKYG4M4epih6Xug4pkY4dL22hb
+    ipfsBootNodeAddress: /dns4/oem-ipfs-bn-dscp-ipfs-swarm.oem.svc.cluster.local/tcp/4001/p2p/12D3KooWJ1ZBoSYADNep8S23MPRKYG4M4epih6Xug4pkY4dL22hb
     ipfsSwarmAddrFilters:
       - /ip4/100.64.0.0/ipcidr/10
       - /ip4/169.254.0.0/ipcidr/16
@@ -29,7 +28,6 @@ dscpIpfs:
     dataVolumeSize: 20
   dscpNode:
     enabled: true
-    nameOverride: vitalamnode
     node:
       chain: inteli-stage
       role: full
@@ -49,7 +47,7 @@ dscpIpfs:
         - "--unsafe-ws-external"
         - "--unsafe-rpc-external"
         - "--pruning 100"
-        - "--bootnodes '/dns4/oem-bn-vitalam-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
+        - "--bootnodes '/dns4/oem-bn-dscp-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
     image:
       tag: v3.0.0
     storageClass: ebs-sc-substrate

--- a/clusters/inteli-stage/oem/bootnode/values.yaml
+++ b/clusters/inteli-stage/oem/bootnode/values.yaml
@@ -1,4 +1,3 @@
-nameOverride: vitalam-node
 node:
   chain: inteli-stage
   role: full

--- a/clusters/inteli-stage/oem/ipfs-bootnode/values.yaml
+++ b/clusters/inteli-stage/oem/ipfs-bootnode/values.yaml
@@ -1,4 +1,3 @@
-nameOverride: vitalam-ipfs
 config:
   logLevel: info
   ipfsLogLevel: fatal
@@ -23,7 +22,6 @@ storage:
 
 dscpNode:
   enabled: true
-  nameOverride: vitalamnode
   node:
     chain: inteli-stage
     role: full
@@ -43,7 +41,7 @@ dscpNode:
       - "--unsafe-ws-external"
       - "--unsafe-rpc-external"
       - "--pruning 100"
-      - "--bootnodes '/dns4/oem-bn-vitalam-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
+      - "--bootnodes '/dns4/oem-bn-dscp-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
   image:
     tag: v3.0.0
   storageClass: ebs-sc-substrate

--- a/clusters/inteli-stage/oem/values-validator.yaml
+++ b/clusters/inteli-stage/oem/values-validator.yaml
@@ -1,4 +1,3 @@
-nameOverride: vitalam-node
 node:
   chain: inteli-stage
   role: validator
@@ -18,7 +17,7 @@ node:
     - "--rpc-cors=all"
     - "--unsafe-ws-external"
     - "--unsafe-rpc-external"
-    - "--bootnodes '/dns4/oem-bn-vitalam-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
+    - "--bootnodes '/dns4/oem-bn-dscp-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
 image:
   tag: v3.0.0
 storageClass: ebs-sc-substrate

--- a/clusters/inteli-stage/t1/api/values.yaml
+++ b/clusters/inteli-stage/t1/api/values.yaml
@@ -4,14 +4,13 @@ ingress:
   className: nginx-t1
 dscpIpfs:
   enabled: true
-  nameOverride: vitalamipfs
   storage:
     storageClass: ebs-sc-ipfs
     dataVolumeSize: 20
   config:
     logLevel: info
     ipfsLogLevel: fatal
-    ipfsBootNodeAddress: /dns4/oem-ipfs-bn-vitalam-ipfs-swarm.oem.svc.cluster.local/tcp/4001/p2p/12D3KooWJ1ZBoSYADNep8S23MPRKYG4M4epih6Xug4pkY4dL22hb
+    ipfsBootNodeAddress: /dns4/oem-ipfs-bn-dscp-ipfs-swarm.oem.svc.cluster.local/tcp/4001/p2p/12D3KooWJ1ZBoSYADNep8S23MPRKYG4M4epih6Xug4pkY4dL22hb
     ipfsSwarmAddrFilters:
       - /ip4/100.64.0.0/ipcidr/10
       - /ip4/169.254.0.0/ipcidr/16
@@ -29,7 +28,6 @@ dscpIpfs:
       - /ip6/fe80::/ipcidr/10
   dscpNode:
     enabled: true
-    nameOverride: vitalamnode
     node:
       chain: inteli-stage
       role: full
@@ -49,7 +47,7 @@ dscpIpfs:
         - "--unsafe-ws-external"
         - "--unsafe-rpc-external"
         - "--pruning 100"
-        - "--bootnodes '/dns4/oem-bn-vitalam-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
+        - "--bootnodes '/dns4/oem-bn-dscp-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
     image:
       tag: v3.0.0
     storageClass: ebs-sc-substrate

--- a/clusters/inteli-stage/t1/values-validator.yaml
+++ b/clusters/inteli-stage/t1/values-validator.yaml
@@ -1,4 +1,3 @@
-nameOverride: vitalam-node
 node:
   chain: inteli-stage
   role: validator
@@ -18,7 +17,7 @@ node:
     - "--rpc-cors=all"
     - "--unsafe-ws-external"
     - "--unsafe-rpc-external"
-    - "--bootnodes '/dns4/oem-bn-vitalam-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
+    - "--bootnodes '/dns4/oem-bn-dscp-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
 image:
   tag: v3.0.0
 storageClass: ebs-sc-substrate

--- a/clusters/inteli-stage/t2/api/values.yaml
+++ b/clusters/inteli-stage/t2/api/values.yaml
@@ -4,14 +4,13 @@ ingress:
   className: nginx-t2
 dscpIpfs:
   enabled: true
-  nameOverride: vitalamipfs
   storage:
     storageClass: ebs-sc-ipfs
     dataVolumeSize: 20
   config:
     logLevel: info
     ipfsLogLevel: fatal
-    ipfsBootNodeAddress: /dns4/oem-ipfs-bn-vitalam-ipfs-swarm.oem.svc.cluster.local/tcp/4001/p2p/12D3KooWJ1ZBoSYADNep8S23MPRKYG4M4epih6Xug4pkY4dL22hb
+    ipfsBootNodeAddress: /dns4/oem-ipfs-bn-dscp-ipfs-swarm.oem.svc.cluster.local/tcp/4001/p2p/12D3KooWJ1ZBoSYADNep8S23MPRKYG4M4epih6Xug4pkY4dL22hb
     ipfsSwarmAddrFilters:
       - /ip4/100.64.0.0/ipcidr/10
       - /ip4/169.254.0.0/ipcidr/16
@@ -29,7 +28,6 @@ dscpIpfs:
       - /ip6/fe80::/ipcidr/10
   dscpNode:
     enabled: true
-    nameOverride: vitalamnode
     node:
       chain: inteli-stage
       role: full
@@ -49,7 +47,7 @@ dscpIpfs:
         - "--unsafe-ws-external"
         - "--unsafe-rpc-external"
         - "--pruning 100"
-        - "--bootnodes '/dns4/oem-bn-vitalam-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
+        - "--bootnodes '/dns4/oem-bn-dscp-node-0-rc-p2p.oem.svc.cluster.local/tcp/30333/p2p/12D3KooWQSy2rqKyrkyqnniFkLg3A8UFn6ChLBoRxj4LRoyGgUnf'"
     image:
       tag: v3.0.0
     storageClass: ebs-sc-substrate


### PR DESCRIPTION
As we're resetting the staging cluster we might as well remove the `nameOverride`s and finish the rename. 