### PR TITLE
Change DSCP to Veritable

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=DSCP). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported by contacting the project team at [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=Veritable). All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. The project team's obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
-# Contributing to dscp-flux-infra
+# Contributing to veritable-flux-infra
 
 Firstly, we would like to thank you for taking the time to contribute!
 
-The following is a set of guidelines for contributing to DSCP and its packages, which are hosted on the [digicatapult](https://github.com/digicatapult) organisation on GitHub. These are mostly guidelines, not rules. Use your best judgement, and feel free to propose changes to this document in a pull request.
+The following is a set of guidelines for contributing to Veritable and its packages, which are hosted on the [digicatapult](https://github.com/digicatapult) organisation on GitHub. These are mostly guidelines, not rules. Use your best judgement, and feel free to propose changes to this document in a pull request.
 
 #### Table Of Contents
 
@@ -24,7 +24,7 @@ The following is a set of guidelines for contributing to DSCP and its packages, 
 
 ## Code of Conduct
 
-This project and all those participating in it are governed by the [Digital Catapult's Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behaviour to [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=DSCP).
+This project and all those participating in it are governed by the [Digital Catapult's Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behaviour to [opensource@digicatapult.org.uk](mailto:opensource@digicatapult.org.uk?subject=Veritable).
 
 ## FAQs
 
@@ -34,7 +34,7 @@ We don't have any frequently asked questions yet.
 
 ### Reporting Bugs
 
-This section guides you through submitting a bug report for dscp-flux-infra. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
+This section guides you through submitting a bug report for veritable-flux-infra. Following these guidelines helps maintainers and the community understand your report :pencil:, reproduce the behaviour :computer: :computer:, and find related reports :mag_right:.
 
 Before creating bug reports, please check [this list](#before-submitting-a-bug-report) as you might find out that you don't need to create one. When you are creating a bug report, please [include as many details as possible](#how-do-i-submit-a-good-bug-report). Fill out [the required template](https://github.com/digicatapult/dscp-flux-infra/blob/main/.github/ISSUE_TEMPLATE/bug_report.md), the information it asks for helps us resolve issues faster.
 
@@ -56,24 +56,24 @@ Explain the problem and include additional details to help maintainers reproduce
 - **Describe the behaviour you observed after following the steps** and point out what exactly is the problem with that behaviour.
 - **Explain which behaviour you expected to see instead and why.**
 - **Include screenshots and animated GIFs** which show you following the described steps and clearly demonstrate the problem. If you use the keyboard while following the steps, \*\*record the GIF with the [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/Xaviju/byzanzUI) on Linux.
-- **If you're reporting that dscp-flux-infra crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
+- **If you're reporting that veritable-flux-infra crashed**, include a crash report with a stack trace from the operating system. On macOS, the crash report will be available in `Console.app` under "Diagnostic and usage information" > "User diagnostic reports". Include the crash report in the issue in a [code block](https://help.github.com/articles/markdown-basics/#multiple-lines), a [file attachment](https://help.github.com/articles/file-attachments-on-issues-and-pull-requests/), or put it in a [gist](https://gist.github.com/) and provide link to that gist.
 - **If the problem wasn't triggered by a specific action**, describe what you were doing before the problem happened and share more information using the guidelines below.
 
 Provide more context by answering these questions:
 
-- **Did the problem start happening recently** (e.g. after updating to a new version of dscp-flux-infra) or was this always a problem?
-- If the problem started happening recently, **can you reproduce the problem in an older version of dscp-flux-infra?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of dscp-flux-infra from [the releases page](https://github.com/digicatapult/dscp-flux-infra/releases).
+- **Did the problem start happening recently** (e.g. after updating to a new version of veritable-flux-infra) or was this always a problem?
+- If the problem started happening recently, **can you reproduce the problem in an older version of veritable-flux-infra?** What's the most recent version in which the problem doesn't happen? You can checkout older versions of veritable-flux-infra from [the releases page](https://github.com/digicatapult/dscp-flux-infra/releases).
 - **Can you reliably reproduce the issue?** If not, provide details about how often the problem happens and under which conditions it normally happens.
 
 Include details about your configuration and environment:
 
-- **Which version of dscp-flux-infra are you using?** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed dscp-flux-infra to**?
-- **Are you running dscp-flux-infra in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
+- **Which version of eritable-flux-infra are you using?** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed veritable-flux-infra to**?
+- **Are you running veritable-flux-infra in a virtual machine?** If so, which VM software are you using and which operating systems and versions are used for the host and the guest?
 
 ### Suggesting Enhancements
 
-This section guides you through submitting an enhancement suggestion for dscp-flux-infra, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
+This section guides you through submitting an enhancement suggestion for veritable-flux-infra, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion :pencil: and find related suggestions :mag_right:.
 
 Before creating enhancement suggestions, please check [this list](#before-submitting-an-enhancement-suggestion) as you might find out that you don't need to create one. When you are creating an enhancement suggestion, please [include as many details as possible](#how-do-i-submit-a-good-enhancement-suggestion). Fill in [the template](https://github.com/digicatapult/dscp-flux-infra/blob/main/.github/ISSUE_TEMPLATE/feature_request.md), including the steps that you imagine you would take if the feature you're requesting existed.
 
@@ -89,19 +89,19 @@ Enhancement suggestions are tracked as [GitHub issues](https://guides.github.com
 - **Provide a step-by-step description of the suggested enhancement** in as many details as possible.
 - **Provide specific examples to demonstrate the steps**. Include copy/pasteable snippets which you use in those examples, as [Markdown code blocks](https://help.github.com/articles/markdown-basics/#multiple-lines).
 - **Describe the current behaviour** and **explain which behaviour you expected to see instead** and why.
-- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of dscp-flux-infra which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
-- **Explain why this enhancement would be useful** to most dscp-flux-infra users.
+- **Include screenshots and animated GIFs** which help you demonstrate the steps or point out the part of veritable-flux-infra which the suggestion is related to. You can use [this tool](https://www.cockos.com/licecap/) to record GIFs on macOS and Windows, and [this tool](https://github.com/colinkeenan/silentcast) or [this tool](https://github.com/GNOME/byzanz) on Linux.
+- **Explain why this enhancement would be useful** to most veritable-flux-infra users.
 - **List some other text editors or applications where this enhancement exists.**
-- **Specify which version of dscp-flux-infra you're using.** You can get the exact version from the version attribute within package.json.
-- **What's the name and version of the OS you've deployed dscp-flux-infra to**?
+- **Specify which version of veritable-flux-infra you're using.** You can get the exact version from the version attribute within package.json.
+- **What's the name and version of the OS you've deployed veritable-flux-infra to**?
 
 ### Pull Requests
 
 The process described here has several goals:
 
-- Maintain dscp-flux-infra's quality
+- Maintain veritable-flux-infra's quality
 - Fix problems that are important to users
-- Enable a sustainable system for dscp-flux-infra's maintainers to review contributions
+- Enable a sustainable system for veritable-flux-infra's maintainers to review contributions
 
 Please follow these steps to have your contribution considered by the maintainers:
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# DSCP Flux Infra
+# Veritable Flux Infra
 
-Work in progress flux repo to bring up a DSCP kubernetes chain.
+Work in progress flux repo to bring up a Veritable kubernetes chain.
 
 ## Getting started
 
-To get started using the dscp-flux-infra in a local kind cluster please see [here](./docs/getting-started.md).
+To get started using the veritable-flux-infra in a local kind cluster please see [here](./docs/getting-started.md).
 
 ## Repository structure
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,15 +17,16 @@ Before getting started make sure you have the following installed:
 
 ## Setting up Kind and Flux
 
-Run 
+Run
+
 ```console
 ./scripts/add-kind-cluster.sh
 ```
 
 This will setup our kind cluster and also provision a local docker registry that is [accessible from within the kind cluster](https://kind.sigs.k8s.io/docs/user/local-registry/#using-the-registry).
 
+Run
 
-Run 
 ```console
 ./scripts/install-flux.sh
 ```
@@ -34,13 +35,16 @@ Once this has completed you will have a functioning flux cluster.
 
 ## Getting an API Token
 
-We use a combination of Ory [Hydra](https://www.ory.sh/docs/hydra) and Ory [Oathkeeper](https://www.ory.sh/docs/oathkeeper) for creating and storing OAuth2 access tokens which are in turn used to access the various APIs used in the dscp project.
+We use a combination of Ory [Hydra](https://www.ory.sh/docs/hydra) and Ory [Oathkeeper](https://www.ory.sh/docs/oathkeeper) for creating and storing OAuth2 access tokens which are in turn used to access the various APIs used in the Veritable project.
 
 To obtain an API token Run
+
 ```console
 ./scripts/get-hydra-token.sh
 ```
+
 Once this has completed you will need to set your token in the form of a header
+
 ```
 Authorization: Bearer <token>
 ```
@@ -132,7 +136,7 @@ spec:
       # `chart` refers to the name of the chart to deploy from the repository
       # and `version` the specific version
       chart: stats-api
-      version: "0.0.5"
+      version: '0.0.5'
   # secrets can be pulled in from sops secrets defined on a per-cluster basis
   # at /clusters/{CLUSTER_NAME}/secrets/api-redis-creds.yaml
   # The secrets must be present for all clusters!
@@ -159,7 +163,7 @@ spec:
       annotations:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/rewrite-target: /$2
-      path: "/api(/|$)(.*)"
+      path: '/api(/|$)(.*)'
   interval: 10m0s
 ```
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -136,7 +136,7 @@ spec:
       # `chart` refers to the name of the chart to deploy from the repository
       # and `version` the specific version
       chart: stats-api
-      version: '0.0.5'
+      version: "0.0.5"
   # secrets can be pulled in from sops secrets defined on a per-cluster basis
   # at /clusters/{CLUSTER_NAME}/secrets/api-redis-creds.yaml
   # The secrets must be present for all clusters!
@@ -163,7 +163,7 @@ spec:
       annotations:
         kubernetes.io/ingress.class: nginx
         nginx.ingress.kubernetes.io/rewrite-target: /$2
-      path: '/api(/|$)(.*)'
+      path: "/api(/|$)(.*)"
   interval: 10m0s
 ```
 


### PR DESCRIPTION
This renames `DSCP` to `Veritable` where appropriate in markdown files.