### PR TITLE
Use babe instead of aura

### DIFF
--- a/scripts/make-cluster-node-secret.sh
+++ b/scripts/make-cluster-node-secret.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 print_usage() {
-  echo "Makes a kubernetes secret containing keys for a dscp-node. The final line of this script will output a JSON object containing the new node's PeerId, AuraId and GrandpaId."
+  echo "Makes a kubernetes secret containing keys for a dscp-node. The final line of this script will output a JSON object containing the new node's PeerId, BabeId and GrandpaId."
   echo ""
   echo "Usage:"
   echo "  ./scripts/make-cluster-node-secret.sh [ -h ] [ -f ] [ -n <namespace> ] [ -c <container> ] <cluster_name> <node_name>"
@@ -158,7 +158,7 @@ create_k8s_secret() {
   local namespace=$2
   local node_name=$3
   local node_key=$4
-  local aura_seed=$5
+  local babe_seed=$5
   local grandpa_seed=$6
 
   printf "Generating k8s secret for $node_name..." >&2
@@ -166,7 +166,7 @@ create_k8s_secret() {
     --type=Opaque \
     --namespace=$namespace \
     --from-literal=node_id=$node_key \
-    --from-literal=aura_seed="$aura_seed" \
+    --from-literal=babe_seed="$babe_seed" \
     --from-literal=grandpa_seed="$grandpa_seed" \
     --dry-run=client \
     --output=yaml > ./clusters/${cluster}/secrets/${node_name}_${namespace}_node-keys.unc.yaml
@@ -191,18 +191,18 @@ pull_container $CONTAINER
 # Generate keys
 generate_node_key $CONTAINER
 generate_authority_key $CONTAINER Sr25519
-AURA_ADDR=$AUTH_ADDR
-AURA_SEED=$AUTH_KEY
+BABE_ADDR=$AUTH_ADDR
+BABE_SEED=$AUTH_KEY
 generate_authority_key $CONTAINER Ed25519
 GRANDPA_ADDR=$AUTH_ADDR
 GRANDPA_SEED=$AUTH_KEY
 
 # generate kubernetes secret
-create_k8s_secret "$CLUSTER" "$NAMESPACE" "$NODE_NAME" "$NODE_KEY" "$AURA_SEED" "$GRANDPA_SEED"
+create_k8s_secret "$CLUSTER" "$NAMESPACE" "$NODE_NAME" "$NODE_KEY" "$BABE_SEED" "$GRANDPA_SEED"
 
 # Generate output as JSON
 echo $(jq --null-input \
   --arg node_id $NODE_ID \
-  --arg aura_id $AURA_ADDR \
+  --arg babe_id $BABE_ADDR \
   --arg grandpa_id $GRANDPA_ADDR \
-  '{ "nodeId": $node_id, "auraId": $aura_id, "grandpaId": $grandpa_id }')
+  '{ "nodeId": $node_id, "babeId": $babe_id, "grandpaId": $grandpa_id }')

--- a/scripts/make-new-cluster-genesis.sh
+++ b/scripts/make-new-cluster-genesis.sh
@@ -278,7 +278,7 @@ generate_node() {
 
   local output=
   local node_id=
-  local aura_id=
+  local babe_id=
   local grandpa_id=
   local owner_name=
   local owner_namespace=
@@ -299,11 +299,11 @@ generate_node() {
     printf "OK\n" >&2
     # extract ids
     node_id=$(echo $output | jq -r '.nodeId')
-    aura_id=$(echo $output | jq -r '.auraId')
+    babe_id=$(echo $output | jq -r '.babeId')
     grandpa_id=$(echo $output | jq -r '.grandpaId')
     # update genesis
     if [ "$type" == "validator" ]; then
-      GENESIS=$(echo $GENESIS | jq --arg aura_id $aura_id '.genesis.runtime.aura.authorities += [$aura_id]')
+      GENESIS=$(echo $GENESIS | jq --arg babe_id $babe_id '.genesis.runtime.babe.authorities += [[$babe_id, 1]]')
       GENESIS=$(echo $GENESIS | jq --arg grandpa_id $grandpa_id '.genesis.runtime.grandpa.authorities += [[$grandpa_id, 1]]')
     fi
     # convert node_id to hex
@@ -354,7 +354,7 @@ GENESIS=$(echo $GENESIS | jq --arg cluster ${CLUSTER//[-]/_} '.id |= $cluster')
 GENESIS=$(echo $GENESIS | jq '.chainType |= "Live"')
 
 # remove all pallet configuration
-GENESIS=$(echo $GENESIS | jq '.genesis.runtime.aura.authorities |= []')
+GENESIS=$(echo $GENESIS | jq '.genesis.runtime.babe.authorities |= []')
 GENESIS=$(echo $GENESIS | jq '.genesis.runtime.grandpa.authorities |= []')
 GENESIS=$(echo $GENESIS | jq '.genesis.runtime.balances.balances |= []')
 GENESIS=$(echo $GENESIS | jq '.genesis.runtime.nodeAuthorization.nodes |= []')


### PR DESCRIPTION
Will add same changes to https://github.com/digicatapult/l3-flux-infra once ready.

Update genesis scripts to use babe instead of aura. Chain spec has changed from:
```
      "aura": {
        "authorities": [
          "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
          "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
          "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y"
        ]
      },
```
to
```
      "babe": {
        "authorities": [
          [
            "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY",
            1
          ],
          [
            "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
            1
          ],
          [
            "5FLSigC9HGRKVhB9FiEo4Y3koPsNmBmLJbpXg2mp1hXcS59Y",
            1
          ]
        ],
        "epochConfig": {
          "c": [
            1,
            4
          ],
          "allowed_slots": "PrimaryAndSecondaryPlainSlots"
        }
```